### PR TITLE
chore: migrate Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
This is a small Renovate config migration cleanup.

The Dependency Dashboard currently shows **Config Migration Needed**, and this repo's `renovate.json` only extends the deprecated `config:base` preset. This updates it to `config:recommended`, which is Renovate's current preset replacement.

I kept the change intentionally narrow:
- only `renovate.json`
- no registry/auth/package rules changed
- JSON syntax validated with `python3 -m json.tool renovate.json`

If useful, this same low-risk dashboard cleanup pattern appears to repeat across several NodeBB plugin repos.